### PR TITLE
plt.close() calls for file count and replay increment plot scripts

### DIFF
--- a/src/score_plotting/core_scripts/plot_file_counts.py
+++ b/src/score_plotting/core_scripts/plot_file_counts.py
@@ -372,6 +372,7 @@ def plot_file_counts(experiments, metric, metrics_df, work_dir, fig_base_fn,
                             experiment_name=expt_name)  
 
     save_figure(fig_fn)
+    plt.close()
 
 @dataclass
 class PlotFileCountRequest(PlotInnovStatsRequest):

--- a/src/score_plotting/core_scripts/plot_increments.py
+++ b/src/score_plotting/core_scripts/plot_increments.py
@@ -425,6 +425,7 @@ def plot_increments(experiments, stat, metric, metrics_df, work_dir, fig_base_fn
                             experiment_name=expt_name)
 
     save_figure(fig_fn)
+    plt.close()
 
 @dataclass
 class PlotIncrementRequest(PlotInnovStatsRequest):


### PR DESCRIPTION
Close figures after writing them to disk to mitigate memory leaks when generating large numbers of figures.